### PR TITLE
Skip over interfaces with no raw address (rather than crashing).

### DIFF
--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -49,8 +49,13 @@ def str2mac(s):
 
     
 def get_if_addr(iff):
-    return socket.inet_ntoa(get_if_raw_addr(iff))
-    
+    raw_addr = get_if_raw_addr(iff)
+    if raw_addr:
+        return socket.inet_ntoa(raw_addr)
+    else:
+        return None
+
+
 def get_if_hwaddr(iff):
     mac = get_if_raw_hwaddr(iff)
     return str2mac(mac)

--- a/scapy/arch/unix.py
+++ b/scapy/arch/unix.py
@@ -80,7 +80,8 @@ def read_routes():
             gw = '0.0.0.0'
         if netif is not None:
             ifaddr = scapy.arch.get_if_addr(netif)
-            routes.append((dest,netmask,gw,netif,ifaddr))
+            if ifaddr:
+                routes.append((dest, netmask, gw, netif, ifaddr))
         else:
             pending_if.append((dest,netmask,gw))
 


### PR DESCRIPTION
I get an instant crash if I import `scapy` while I have virtual machines running (VirtualBox via Vagrant), because one of the tunnels, `vboxnet1`, doesn't have a raw address. Here's a quick fix.