### PR TITLE
Fix decoding of AAAA responses.

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -225,7 +225,9 @@ class RDataField(StrLenField):
                 s = ret_s
         elif pkt.type == 28: # AAAA
             if s:
-                s = inet_pton(socket.AF_INET6, s.decode("utf-8"))
+                if type(s) is bytes:
+                    s = s.decode('utf-8')
+                s = inet_pton(socket.AF_INET6, s)
         return s
 
 class RDLenField(Field):


### PR DESCRIPTION
It seems the response for AAAA records can come back already encoded as a `str`. Skip decoding if not needed.